### PR TITLE
Frontend screenshot policy

### DIFF
--- a/.cursor/rules/frontend-screenshot-policy.mdc
+++ b/.cursor/rules/frontend-screenshot-policy.mdc
@@ -1,0 +1,35 @@
+---
+description: Require screenshots in PRs that touch frontend code (markup, styling, UI components)
+alwaysApply: true
+---
+
+# Frontend Screenshot Policy
+
+Any pull request that includes **frontend changes** must contain at least one **screenshot** (or screen recording / GIF for animations) in the PR description showing the visual result of the change.
+
+## What counts as a frontend change
+
+A PR is considered frontend-related if it modifies any of the following:
+
+- **Markup / JSX** – `.tsx`, `.jsx` files under `src/routes/`, `src/ui/`, or any component directory.
+- **Styles** – `.module.css`, `.css`, or any styling-related file.
+- **Design tokens** – Changes to `tokens.module.css` or other shared style constants.
+- **Assets** – Images, icons, fonts, or other visual assets.
+- **Layout or UX changes** – Route-level layout shifts, new pages, component reordering, responsive behavior.
+
+## What to include
+
+- **Before / after screenshots** when modifying existing UI (side-by-side or stacked).
+- **Single screenshot** for new UI that did not exist before.
+- **GIF or short video** for animations, transitions, or interactive behavior (e.g. the scatter-on-fulfill animation).
+- Screenshots should show the **relevant viewport** (desktop; mobile if responsive changes are involved).
+
+## Where to put them
+
+- Embed directly in the **PR description body** using markdown image syntax (`![description](url)`).
+- If the PR is created by an automated tool or CI, the agent/author must add screenshots before requesting review.
+
+## Exceptions
+
+- Pure refactors with **zero visual change** (e.g. renaming CSS class internals, extracting a component with identical output) may skip screenshots but should explicitly state "No visual change" in the PR description.
+- Backend-only PRs (API, DB, server logic) that do not touch any of the file types above are exempt.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,8 @@ SLOP is a single shared office shopping list app. Colleagues add items they need
 │   │   ├── slop-ux-and-ui.mdc
 │   │   ├── slop-design-system.mdc
 │   │   ├── slop-styling.mdc
-│   │   └── context7-technical.mdc
+│   │   ├── context7-technical.mdc
+│   │   └── frontend-screenshot-policy.mdc
 │   └── skills/                  # Reusable agent skills (general purpose)
 │
 └── docs/                        # Additional documentation
@@ -305,6 +306,10 @@ Run all: `bun test` (requires `DATABASE_URL` to point to a running PostgreSQL).
 2. Ensure `.env.local` exists with valid `DATABASE_URL`
 3. Run `bun install && bun run db:migrate`
 4. Build: `bun run build` | Dev: `bun run dev` | Test: `bun test`
+
+## PR Screenshot Policy
+
+Any PR that touches frontend code (`.tsx`, `.jsx`, `.module.css`, design tokens, assets, or layout) **must include screenshots** (or GIFs for animations) in the PR description showing the visual result. Use before/after for modifications. Pure refactors with zero visual change may state "No visual change" instead. See `.cursor/rules/frontend-screenshot-policy.mdc` for full details.
 
 ## Scope (MVP)
 


### PR DESCRIPTION
Enforce screenshot inclusion in frontend-related PRs to improve visual review.

This PR introduces a new always-applied rule (`.cursor/rules/frontend-screenshot-policy.mdc`) requiring screenshots for PRs affecting frontend code (e.g., UI/route `.tsx`/`.jsx`, CSS, design tokens, assets, layout/UX changes). It specifies what to include (before/after, single, GIF/video) and where to place them. `AGENTS.md` has been updated to reflect this new policy.

---
<p><a href="https://cursor.com/agents/bc-60f85329-f5c2-4b08-977e-6c391e5a8ff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60f85329-f5c2-4b08-977e-6c391e5a8ff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

