### PR TITLE
Fix toast position and smooth overflow batching

### DIFF
--- a/src/ui/components/Toast.tsx
+++ b/src/ui/components/Toast.tsx
@@ -14,6 +14,7 @@ interface ToastProps {
   toast: ToastData
   onExitComplete: (id: string) => void
   duration?: number
+  forceExit?: boolean
 }
 
 const CheckIcon = () => (
@@ -46,13 +47,17 @@ const CloseIcon = () => (
   </svg>
 )
 
-export function Toast({ toast, onExitComplete, duration = 5000 }: ToastProps) {
+export function Toast({ toast, onExitComplete, duration = 5000, forceExit }: ToastProps) {
   const [isExiting, setIsExiting] = useState(false)
   const [isPaused, setIsPaused] = useState(false)
 
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const elapsedRef = useRef(0)
   const startRef = useRef(Date.now())
+
+  useEffect(() => {
+    if (forceExit && !isExiting) setIsExiting(true)
+  }, [forceExit, isExiting])
 
   useEffect(() => {
     if (isExiting) return

--- a/src/ui/components/ToastContainer.module.css
+++ b/src/ui/components/ToastContainer.module.css
@@ -1,7 +1,8 @@
-/* ── Toast container (fixed viewport anchor) ── */
+/* ── Toast container (fixed viewport anchor, below header) ── */
+/* topBar 56px + small gap */
 .container {
   position: fixed;
-  top: var(--space6);
+  top: calc(56px + var(--space6));
   right: var(--space6);
   z-index: calc(var(--zModal) + 10);
   display: flex;
@@ -30,7 +31,7 @@
 /* ── Mobile: full-width with smaller insets ── */
 @media (max-width: 640px) {
   .container {
-    top: var(--space4);
+    top: calc(56px + var(--space6));
     right: var(--space3);
     left: var(--space3);
     width: auto;

--- a/src/ui/components/ToastContainer.tsx
+++ b/src/ui/components/ToastContainer.tsx
@@ -4,6 +4,8 @@ import { Toast, type ToastData, type ToastVariant } from './Toast'
 import styles from './ToastContainer.module.css'
 
 const COLLAPSE_DURATION_MS = 200
+const FORCE_EXIT_STAGGER_MS = 80
+const MAX_TOAST_BUFFER = 12
 
 interface ToastContainerProps {
   toasts: ToastData[]
@@ -11,17 +13,29 @@ interface ToastContainerProps {
   maxVisible?: number
 }
 
+/**
+ * Renders ALL toasts (no slicing). When the count exceeds maxVisible,
+ * oldest overflow toasts are force-exited with a stagger delay so
+ * they animate out individually instead of disappearing in batches.
+ */
 export function ToastContainer({
   toasts,
   onRemove,
-  maxVisible = 4,
+  maxVisible = 5,
 }: ToastContainerProps) {
-  const visibleToasts = toasts.slice(-maxVisible)
+  const excessCount = Math.max(0, toasts.length - maxVisible)
 
   return (
     <div className={styles.container} aria-label="Notifications">
-      {visibleToasts.map((toast) => (
-        <ToastSlot key={toast.id} toast={toast} onRemove={onRemove} />
+      {toasts.map((toast, index) => (
+        <ToastSlot
+          key={toast.id}
+          toast={toast}
+          onRemove={onRemove}
+          forceExitDelay={
+            index < excessCount ? index * FORCE_EXIT_STAGGER_MS : undefined
+          }
+        />
       ))}
     </div>
   )
@@ -32,15 +46,33 @@ export function ToastContainer({
  * when one exits. Two-phase exit:
  *   1. Toast slides out (handled by Toast component via CSS animation)
  *   2. Slot collapses height (grid-template-rows 1fr → 0fr)
+ *
+ * When forceExitDelay is set, the toast is scheduled for early dismissal
+ * after the given delay (ms), creating a staggered overflow exit.
  */
 function ToastSlot({
   toast,
   onRemove,
+  forceExitDelay,
 }: {
   toast: ToastData
   onRemove: (id: string) => void
+  forceExitDelay?: number
 }) {
   const [collapsed, setCollapsed] = useState(false)
+  const [forceExit, setForceExit] = useState(false)
+
+  useEffect(() => {
+    if (forceExitDelay == null || forceExit) return
+
+    if (forceExitDelay === 0) {
+      setForceExit(true)
+      return
+    }
+
+    const timer = setTimeout(() => setForceExit(true), forceExitDelay)
+    return () => clearTimeout(timer)
+  }, [forceExitDelay, forceExit])
 
   const handleExitComplete = useCallback(() => {
     setCollapsed(true)
@@ -55,7 +87,11 @@ function ToastSlot({
   return (
     <div className={styles.slot} data-collapsed={collapsed || undefined}>
       <div className={styles.slotInner}>
-        <Toast toast={toast} onExitComplete={handleExitComplete} />
+        <Toast
+          toast={toast}
+          onExitComplete={handleExitComplete}
+          forceExit={forceExit}
+        />
       </div>
     </div>
   )
@@ -67,7 +103,13 @@ export function useToasts() {
 
   const addToast = useCallback((message: string, variant: ToastVariant) => {
     const id = `toast-${Date.now()}-${counterRef.current++}`
-    setToasts((prev) => [...prev, { id, message, variant }])
+    setToasts((prev) => {
+      const next = [...prev, { id, message, variant }]
+      if (next.length > MAX_TOAST_BUFFER) {
+        return next.slice(-MAX_TOAST_BUFFER)
+      }
+      return next
+    })
   }, [])
 
   const removeToast = useCallback((id: string) => {


### PR DESCRIPTION
## Summary

- **Repositioned toast container** below the sticky header (`56px + 24px` gap) so notifications no longer obstruct the top bar on desktop or mobile.
- **Eliminated batch appearance** of toasts: replaced the hard `slice(-maxVisible)` cap with a force-exit queue. All toasts render immediately with their own enter animation; overflow toasts are stagger-dismissed (80ms apart) so they animate out individually.
- **Added safety buffer** (max 12 toasts in the array) to prevent unbounded growth during rapid-fire actions.

## Test plan

- [ ] Trigger 6+ toast-producing actions in quick succession — toasts should enter one by one, not in batches of 4
- [ ] Verify toasts appear below the header and don't overlap navigation
- [ ] Verify mobile layout positions toasts correctly below the header
- [ ] Hover over a toast to pause its timer; confirm it resumes on mouse leave
- [ ] Dismiss a toast manually via the close button

No visual change screenshot needed — this is a positioning + animation behavior fix (no new UI elements).


Made with [Cursor](https://cursor.com)